### PR TITLE
Fix directory removal method

### DIFF
--- a/src/main/fileSystem/fileSystemHandlers.ts
+++ b/src/main/fileSystem/fileSystemHandlers.ts
@@ -175,7 +175,7 @@ export function setupFileSystemHandlers() {
   // ディレクトリの削除
   ipcMain.handle('fs:remove-directory', async (event, dirPath) => {
     try {
-      await fs.rmdir(dirPath, { recursive: true });
+      await fs.rm(dirPath, { recursive: true, force: true });
       return true;
     } catch (error) {
       console.error('Error deleting directory:', error);


### PR DESCRIPTION
## Summary
- replace deprecated `fs.rmdir` usage in `fileSystemHandlers.ts` with `fs.rm`

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840579c7f948329925c0f0d2f572d6c