### PR TITLE
Fix toast timeout handling

### DIFF
--- a/src/renderer/hooks/useToast.test.tsx
+++ b/src/renderer/hooks/useToast.test.tsx
@@ -1,0 +1,49 @@
+import { act, renderHook } from '@testing-library/react';
+import { useAtom } from 'jotai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toastAtom } from '../stores/toastAtom';
+import { useToast } from './useToast';
+
+// Helper hook to access toast atom alongside useToast
+const useToastWithAtom = () => {
+  const { showToast } = useToast();
+  const [toast] = useAtom(toastAtom);
+  return { showToast, toast };
+};
+
+describe('useToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllTimers();
+  });
+
+  it('clears previous timeout when showing a new toast', () => {
+    const { result } = renderHook(() => useToastWithAtom());
+
+    act(() => {
+      result.current.showToast('first', 'success');
+    });
+
+    // advance time a little and show another toast
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      result.current.showToast('second', 'error');
+    });
+
+    // advance time to when first toast would have expired
+    act(() => {
+      vi.advanceTimersByTime(2000); // total 3000ms since first toast
+    });
+
+    // toast should still be visible because timeout was cleared
+    expect(result.current.toast.message).toBe('second');
+
+    // after full duration from second toast, it should clear
+    act(() => {
+      vi.advanceTimersByTime(1000); // now 3000ms since second toast
+    });
+
+    expect(result.current.toast.message).toBe('');
+  });
+});

--- a/src/renderer/hooks/useToast.tsx
+++ b/src/renderer/hooks/useToast.tsx
@@ -5,6 +5,8 @@ import { X } from 'lucide-react';
 
 import { toastAtom } from '../stores/toastAtom';
 
+const TOAST_TIMEOUT_MS = 3000;
+
 export const useToast = () => {
   const [toast, setToast] = useAtom(toastAtom);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/renderer/hooks/useToast.tsx
+++ b/src/renderer/hooks/useToast.tsx
@@ -11,6 +11,9 @@ export const useToast = () => {
 
   const showToast = (message: string, type: 'success' | 'error') => {
     setToast({ message, type });
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
     setTimeoutId(setTimeout(() => clearToast(), 3000));
   };
 

--- a/src/renderer/hooks/useToast.tsx
+++ b/src/renderer/hooks/useToast.tsx
@@ -14,7 +14,7 @@ export const useToast = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
-    timeoutRef.current = setTimeout(() => clearToast(), 3000);
+    timeoutRef.current = setTimeout(() => clearToast(), TOAST_TIMEOUT_MS);
   };
 
   const clearToast = () => {

--- a/src/renderer/hooks/useToast.tsx
+++ b/src/renderer/hooks/useToast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useAtom } from 'jotai';
 import { X } from 'lucide-react';
@@ -7,14 +7,14 @@ import { toastAtom } from '../stores/toastAtom';
 
 export const useToast = () => {
   const [toast, setToast] = useAtom(toastAtom);
-  const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const showToast = (message: string, type: 'success' | 'error') => {
     setToast({ message, type });
-    if (timeoutId) {
-      clearTimeout(timeoutId);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
     }
-    setTimeoutId(setTimeout(() => clearToast(), 3000));
+    timeoutRef.current = setTimeout(() => clearToast(), 3000);
   };
 
   const clearToast = () => {
@@ -23,11 +23,11 @@ export const useToast = () => {
 
   useEffect(() => {
     return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
     };
-  }, [timeoutId]);
+  }, []);
 
   const Toast = () => {
     return (


### PR DESCRIPTION
## Summary
- prevent stale timers from clearing toasts in `useToast`
- add regression test for clearing old toast timers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684057960f24832988a0bd2ecc5a6e26