### PR TITLE
Add refreshDirectory prop to FileMenu

### DIFF
--- a/src/renderer/components/FileMenu/FileMenu.tsx
+++ b/src/renderer/components/FileMenu/FileMenu.tsx
@@ -20,6 +20,7 @@ type FileMenuProps = {
   handleRename: (file: FileTreeItem, newName: string) => void;
   handleDeleteClick: (file: FileTreeItem) => void;
   showToast: (message: string, type: 'success' | 'error') => void;
+  refreshDirectory: () => void;
 };
 
 export const FileMenu = ({
@@ -29,6 +30,7 @@ export const FileMenu = ({
   handleRename,
   handleDeleteClick,
   showToast,
+  refreshDirectory,
 }: FileMenuProps) => {
   const [isRenaming, setIsRenaming] = useState<boolean>(false);
   const [newName, setNewName] = useState(file.name);
@@ -78,8 +80,8 @@ export const FileMenu = ({
         await window.api.fs.createDirectory(`${file.path}/${newItemName}`);
         showToast(`フォルダ "${newItemName}" を作成しました`, 'success');
       }
-      // 親コンポーネントのloadDirectoryを呼び出す
-      window.api.fs.listFiles(file.path);
+      // 親コンポーネントにディレクトリ再読み込みを依頼
+      refreshDirectory();
       setIsCreatingNew(false);
       setNewItemName('');
       setNewItemType(null);

--- a/src/renderer/components/FileTree/FileTree.tsx
+++ b/src/renderer/components/FileTree/FileTree.tsx
@@ -207,6 +207,7 @@ export const FileTree: React.FC<FileTreeProps> = ({ onFileSelect, onSettingsClic
               handleRename={handleRename}
               handleDeleteClick={handleDeleteClick}
               showToast={showToast}
+              refreshDirectory={() => loadDirectory(currentDir)}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- ファイルメニューのpropsに`refreshDirectory`を追加
- 新規作成成功後に`refreshDirectory()`を呼び出すように変更
- FileTreeで`<FileMenu>`呼び出し時に`refreshDirectory`を渡す
- `window.api.fs.listFiles`の呼び出しを削除

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684060ce65f883298d8cace9544cc19e