### PR TITLE
Fix rename-directory path

### DIFF
--- a/src/main/fileSystem/fileSystemHandlers.ts
+++ b/src/main/fileSystem/fileSystemHandlers.ts
@@ -164,7 +164,7 @@ export function setupFileSystemHandlers() {
   // ディレクトリのリネーム
   ipcMain.handle('fs:rename-directory', async (event, dirPath, newName) => {
     try {
-      await fs.rename(dirPath, newName);
+      await fs.rename(dirPath, path.join(path.dirname(dirPath), newName));
       return true;
     } catch (error) {
       console.error('Error renaming directory:', error);


### PR DESCRIPTION
## Summary
- adjust rename-directory handler to keep directory path when renaming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841cce693b883299bbd056482bd50da