### PR TITLE
Refactor gitignore filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "node-pty": "^1.0.0",
         "openai": "^4.103.0",
         "prismjs": "^1.30.0",
+        "ignore": "^5.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "rollup-plugin-visualizer": "^5.14.0"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "node-pty": "^1.0.0",
     "openai": "^4.103.0",
     "prismjs": "^1.30.0",
+    "ignore": "^5.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rollup-plugin-visualizer": "^5.14.0"

--- a/src/main/git/gitHandlers.ts
+++ b/src/main/git/gitHandlers.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron';
 // @ts-ignore
 import Store from 'electron-store';
 import fs from 'fs';
+import ignore from 'ignore';
 // @ts-ignore
 import git from 'isomorphic-git';
 // @ts-ignore
@@ -40,11 +41,9 @@ export function setupGitHandlers() {
       // gitignoreファイルが存在しない場合は空文字列のまま
     }
 
-    // gitignoreのパターンを配列に変換
-    const ignorePatterns = gitignoreContent
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line && !line.startsWith('#'));
+    // ignoreライブラリでフィルタリングを設定
+    const ig = ignore();
+    ig.add(gitignoreContent);
 
     const status = await git.statusMatrix({
       fs: fs,
@@ -54,13 +53,7 @@ export function setupGitHandlers() {
       filter: (filepath) => {
         // gitignoreのパターンに一致するファイルを除外
         return (
-          !ignorePatterns.some((pattern) => {
-            // シンプルなワイルドカードマッチング
-            const regex = new RegExp(pattern.replace(/\*/g, '.*'));
-            return regex.test(filepath);
-          }) &&
-          !filepath.startsWith('.git') &&
-          !filepath.startsWith('.cursor')
+          !ig.ignores(filepath) && !filepath.startsWith('.git') && !filepath.startsWith('.cursor')
         );
       },
     });


### PR DESCRIPTION
## Summary
- use `ignore` library for git status filtering
- add `ignore` as a dependency

## Testing
- `npm run lint` *(fails: 12 errors, 16 warnings)*
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841cce800588329bc27970c7f4e5c91