### PR TITLE
Validate repo path and add tests

### DIFF
--- a/src/main/git/gitHandlers.test.ts
+++ b/src/main/git/gitHandlers.test.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getRepoPath } from './gitHandlers';
+
+let mockGet: any;
+
+vi.mock('electron-store', () => {
+  return {
+    default: class {
+      get(key: string) {
+        return mockGet(key);
+      }
+    },
+  };
+});
+
+describe('getRepoPath', () => {
+  beforeEach(() => {
+    mockGet = vi.fn();
+  });
+
+  it('指定されたパスを絶対パスで返す', () => {
+    mockGet.mockReturnValue({ rootDirectory: { path: './repo' } });
+    const resolved = getRepoPath();
+    expect(resolved).toBe(path.resolve('./repo'));
+  });
+
+  it('空文字列の場合はエラーを投げる', () => {
+    mockGet.mockReturnValue({ rootDirectory: { path: '' } });
+    expect(() => getRepoPath()).toThrow('リポジトリのパスが設定されていません');
+  });
+
+  it('undefined の場合はエラーを投げる', () => {
+    mockGet.mockReturnValue(undefined);
+    expect(() => getRepoPath()).toThrow('リポジトリのパスが設定されていません');
+  });
+});

--- a/src/main/git/gitHandlers.ts
+++ b/src/main/git/gitHandlers.ts
@@ -16,9 +16,15 @@ const store = new Store<AppSettings>({
 });
 
 // リポジトリのパスを取得する関数
-const getRepoPath = () => {
+export const getRepoPath = () => {
   const settings: AppSettings | undefined = store.get('settings');
-  return settings?.rootDirectory?.path;
+  const repoPath = settings?.rootDirectory?.path;
+
+  if (!repoPath || repoPath.trim() === '') {
+    throw new Error('リポジトリのパスが設定されていません');
+  }
+
+  return path.resolve(repoPath);
 };
 
 const getGitSettings = () => {


### PR DESCRIPTION
## Summary
- export and update `getRepoPath` to validate repository path and return an absolute path
- add tests for the new `getRepoPath` behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d23690448329aac33fbab4b62937