### PR TITLE
Fix unclosed test case

### DIFF
--- a/src/renderer/components/Layout/MainContent.test.tsx
+++ b/src/renderer/components/Layout/MainContent.test.tsx
@@ -115,6 +115,7 @@ describe('MainContent', () => {
       false
     );
     expect(screen.queryByTestId('dirty-indicator')).not.toBeInTheDocument();
+  });
   test('Cmd/Ctrl+S で saveFile が呼ばれる', () => {
     renderMainContent({ selectedFile: 'test.md' }, { content: 'test' });
 


### PR DESCRIPTION
## Summary
- fix closing brace for `isDirtyがfalse` test in MainContent.test.tsx

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684b822c69f883298137bcd6c61611d7