### PR TITLE
Add hook tests for file loader and Git settings

### DIFF
--- a/src/renderer/components/Layout/MainContent.test.tsx
+++ b/src/renderer/components/Layout/MainContent.test.tsx
@@ -115,6 +115,8 @@ describe('MainContent', () => {
       false
     );
     expect(screen.queryByTestId('dirty-indicator')).not.toBeInTheDocument();
+  });
+
   test('Cmd/Ctrl+S で saveFile が呼ばれる', () => {
     renderMainContent({ selectedFile: 'test.md' }, { content: 'test' });
 

--- a/src/renderer/hooks/useFileLoader.test.ts
+++ b/src/renderer/hooks/useFileLoader.test.ts
@@ -1,0 +1,76 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useFileLoader } from './useFileLoader';
+
+describe('useFileLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ファイルパスがnullの場合、初期状態を返す', () => {
+    const { result } = renderHook(() => useFileLoader(null));
+
+    expect(result.current.content).toBe('');
+    expect(result.current.fileInfo).toBeNull();
+    expect(result.current.loadProgress).toBe(0);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('小さなファイルを正常に読み込む', async () => {
+    const info = { size: 100, isLargeFile: false };
+    const fileContent = 'hello';
+    vi.mocked(window.api.fs.getFileInfo).mockResolvedValueOnce(info as any);
+    vi.mocked(window.api.fs.readFile).mockResolvedValueOnce(fileContent);
+    const onLoadComplete = vi.fn();
+
+    const { result } = renderHook(() => useFileLoader('/path/to/file.md', onLoadComplete));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.content).toBe(fileContent);
+    expect(result.current.fileInfo).toEqual(info);
+    expect(result.current.error).toBeNull();
+    expect(result.current.loadProgress).toBe(100);
+    expect(onLoadComplete).toHaveBeenCalledWith(fileContent);
+  });
+
+  it('大きなファイルを段階的に読み込む', async () => {
+    const info = { size: 2000, isLargeFile: true };
+    vi.mocked(window.api.fs.getFileInfo).mockResolvedValueOnce(info as any);
+    vi.mocked(window.api.fs.readFileLines)
+      .mockResolvedValueOnce('chunk1')
+      .mockResolvedValueOnce('');
+    const onLoadComplete = vi.fn();
+
+    const { result } = renderHook(() => useFileLoader('/path/to/large.md', onLoadComplete));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.content).toBe('chunk1');
+    expect(result.current.loadProgress).toBe(100);
+    expect(onLoadComplete).toHaveBeenCalledWith('chunk1');
+  });
+
+  it('読み込み中にエラーが発生した場合、errorが設定される', async () => {
+    const info = { size: 100, isLargeFile: false };
+    const error = new Error('read error');
+    vi.mocked(window.api.fs.getFileInfo).mockResolvedValueOnce(info as any);
+    vi.mocked(window.api.fs.readFile).mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useFileLoader('/path/to/error.md'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe(error);
+    expect(result.current.content).toBe('');
+    expect(result.current.loadProgress).toBe(0);
+  });
+});

--- a/src/renderer/hooks/useGitSettings.test.ts
+++ b/src/renderer/hooks/useGitSettings.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGitSettings } from './useGitSettings';
+
+describe('useGitSettings', () => {
+  const mockShowToast = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ルートディレクトリが設定されていると hasGitSettings が true になる', async () => {
+    vi.mocked(window.api.app.getSettings).mockResolvedValueOnce({
+      rootDirectory: { path: '/repo' },
+    } as any);
+
+    const { result } = renderHook(() => useGitSettings({ showToast: mockShowToast }));
+
+    await waitFor(() => {
+      expect(result.current.hasGitSettings).toBe(true);
+    });
+  });
+
+  it('ルートディレクトリがない場合 hasGitSettings は false', async () => {
+    vi.mocked(window.api.app.getSettings).mockResolvedValueOnce({
+      rootDirectory: { path: '' },
+    } as any);
+
+    const { result } = renderHook(() => useGitSettings({ showToast: mockShowToast }));
+
+    await waitFor(() => {
+      expect(result.current.hasGitSettings).toBe(false);
+    });
+  });
+
+  it('設定取得に失敗した場合、トーストを表示して hasGitSettings は false', async () => {
+    vi.mocked(window.api.app.getSettings).mockRejectedValueOnce(new Error('failed'));
+
+    const { result } = renderHook(() => useGitSettings({ showToast: mockShowToast }));
+
+    await waitFor(() => {
+      expect(result.current.hasGitSettings).toBe(false);
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('Gitの設定を確認できませんでした', 'error');
+  });
+
+  it('checkGitSettings を呼び出すと状態が更新される', async () => {
+    vi.mocked(window.api.app.getSettings).mockResolvedValueOnce({
+      rootDirectory: { path: '' },
+    } as any);
+
+    const { result } = renderHook(() => useGitSettings({ showToast: mockShowToast }));
+
+    await waitFor(() => {
+      expect(result.current.hasGitSettings).toBe(false);
+    });
+
+    vi.mocked(window.api.app.getSettings).mockResolvedValueOnce({
+      rootDirectory: { path: '/repo' },
+    } as any);
+
+    await act(async () => {
+      await result.current.checkGitSettings();
+    });
+
+    expect(result.current.hasGitSettings).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- test `useFileLoader` for success and failure scenarios
- test `useGitSettings` for git configuration detection
- fix missing closing bracket in `MainContent.test.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b820f79b88329bd82392c8292aa56