### PR TITLE
fix: 空ファイル選択時にエディターが表示されない問題を修正

### DIFF
--- a/src/renderer/components/Editor/plugins/FileChangeUpdateStatePlugin.tsx
+++ b/src/renderer/components/Editor/plugins/FileChangeUpdateStatePlugin.tsx
@@ -52,6 +52,7 @@ export function FileChangeUpdateStatePlugin({
             editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
           });
 
+          // エディタをスクロールトップに移動
           requestAnimationFrame(() => {
             const editorElement = document.getElementById('editor');
             if (editorElement) {

--- a/src/renderer/components/Layout/MainContent.tsx
+++ b/src/renderer/components/Layout/MainContent.tsx
@@ -106,7 +106,7 @@ export function MainContent({
               </div>
             )}
 
-            {!isLoading && fileContent && (
+            {!isLoading && fileContent !== null && fileContent !== undefined && (
               <Editor
                 initialContent={fileContent}
                 ref={editorRef}

--- a/src/renderer/components/Search/SearchBar.test.tsx
+++ b/src/renderer/components/Search/SearchBar.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SearchBar } from './SearchBar';
+
+describe('SearchBar', () => {
+  const mockOnSearch = vi.fn();
+  const mockOnClear = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期状態で正しくレンダリングされる', () => {
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    expect(screen.getByPlaceholderText('ファイルを検索...')).toBeInTheDocument();
+    expect(screen.getByLabelText('検索')).toBeInTheDocument();
+    expect(screen.getByLabelText('検索')).toBeDisabled();
+  });
+
+  it('カスタムプレースホルダーを表示する', () => {
+    render(
+      <SearchBar
+        onSearch={mockOnSearch}
+        onClear={mockOnClear}
+        placeholder="カスタムプレースホルダー"
+      />
+    );
+
+    expect(screen.getByPlaceholderText('カスタムプレースホルダー')).toBeInTheDocument();
+  });
+
+  it('テキスト入力時に検索ボタンが有効になる', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+    const searchButton = screen.getByLabelText('検索');
+
+    expect(searchButton).toBeDisabled();
+
+    await user.type(input, 'test');
+
+    expect(searchButton).not.toBeDisabled();
+  });
+
+  it('検索ボタンクリックでonSearchが呼ばれる', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+    const searchButton = screen.getByLabelText('検索');
+
+    await user.type(input, '  test search  ');
+    await user.click(searchButton);
+
+    expect(mockOnSearch).toHaveBeenCalledTimes(1);
+    expect(mockOnSearch).toHaveBeenCalledWith('test search');
+  });
+
+  it('Enterキー押下でonSearchが呼ばれる', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+
+    await user.type(input, 'test search');
+    await user.keyboard('{Enter}');
+
+    expect(mockOnSearch).toHaveBeenCalledTimes(1);
+    expect(mockOnSearch).toHaveBeenCalledWith('test search');
+  });
+
+  it('空白のみの入力では検索されない', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+
+    await user.type(input, '   ');
+    await user.keyboard('{Enter}');
+
+    expect(mockOnSearch).not.toHaveBeenCalled();
+  });
+
+  it('テキスト入力時にクリアボタンが表示される', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+
+    expect(screen.queryByLabelText('検索をクリア')).not.toBeInTheDocument();
+
+    await user.type(input, 'test');
+
+    expect(screen.getByLabelText('検索をクリア')).toBeInTheDocument();
+  });
+
+  it('クリアボタンクリックで入力がクリアされonClearが呼ばれる', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+
+    await user.type(input, 'test');
+
+    const clearButton = screen.getByLabelText('検索をクリア');
+    await user.click(clearButton);
+
+    expect(input).toHaveValue('');
+    expect(mockOnClear).toHaveBeenCalledTimes(1);
+    expect(screen.queryByLabelText('検索をクリア')).not.toBeInTheDocument();
+  });
+
+  it('Escapeキー押下で入力がクリアされonClearが呼ばれる', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+
+    await user.type(input, 'test');
+    await user.keyboard('{Escape}');
+
+    expect(input).toHaveValue('');
+    expect(mockOnClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('disabled状態で入力とボタンが無効になる', () => {
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} disabled={true} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+    const searchButton = screen.getByLabelText('検索');
+
+    expect(input).toBeDisabled();
+    expect(searchButton).toBeDisabled();
+  });
+
+  it('disabled状態でテキストがある場合も検索ボタンは無効', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+    await user.type(input, 'test');
+
+    rerender(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} disabled={true} />);
+
+    const searchButton = screen.getByLabelText('検索');
+    expect(searchButton).toBeDisabled();
+  });
+
+  it('アイコンが正しく表示される', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    // Search icon
+    const searchIcon = document.querySelector('.lucide-search');
+    expect(searchIcon).toBeInTheDocument();
+
+    // X icon appears when text is entered
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+    await user.type(input, 'test');
+
+    const xIcon = document.querySelector('.lucide-x');
+    expect(xIcon).toBeInTheDocument();
+  });
+
+  it('入力値が制御されている', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...') as HTMLInputElement;
+
+    await user.type(input, 'test');
+    expect(input.value).toBe('test');
+
+    await user.clear(input);
+    await user.type(input, 'new value');
+    expect(input.value).toBe('new value');
+  });
+
+  it('複数回の検索が正しく動作する', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar onSearch={mockOnSearch} onClear={mockOnClear} />);
+
+    const input = screen.getByPlaceholderText('ファイルを検索...');
+    const searchButton = screen.getByLabelText('検索');
+
+    // First search
+    await user.type(input, 'first search');
+    await user.click(searchButton);
+
+    expect(mockOnSearch).toHaveBeenCalledTimes(1);
+    expect(mockOnSearch).toHaveBeenCalledWith('first search');
+
+    // Clear and second search
+    await user.clear(input);
+    await user.type(input, 'second search');
+    await user.click(searchButton);
+
+    expect(mockOnSearch).toHaveBeenCalledTimes(2);
+    expect(mockOnSearch).toHaveBeenLastCalledWith('second search');
+  });
+});

--- a/src/renderer/components/Search/SearchResults.test.tsx
+++ b/src/renderer/components/Search/SearchResults.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ISearchResult } from '../../../types/search';
+import { SearchResults } from './SearchResults';
+
+describe('SearchResults', () => {
+  const mockResults: ISearchResult[] = [
+    {
+      path: '/path/to/file1.md',
+      name: 'file1.md',
+      matches: [
+        {
+          line: 1,
+          content: 'This is a test file',
+          highlight: [10, 14],
+        },
+      ],
+    },
+    {
+      path: '/path/to/folder/file2.md',
+      name: 'file2.md',
+      matches: [
+        {
+          line: 5,
+          content: 'Another test content',
+          highlight: [8, 12],
+        },
+      ],
+    },
+  ];
+
+  const mockOnFileClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('検索結果を正しく表示する', () => {
+    render(<SearchResults results={mockResults} onFileClick={mockOnFileClick} />);
+
+    expect(screen.getByText('2件の結果')).toBeInTheDocument();
+    expect(screen.getByText('file1.md')).toBeInTheDocument();
+    expect(screen.getByText('file2.md')).toBeInTheDocument();
+    expect(screen.getByText('/path/to/file1.md')).toBeInTheDocument();
+    expect(screen.getByText('/path/to/folder/file2.md')).toBeInTheDocument();
+  });
+
+  it('ローディング状態を表示する', () => {
+    render(<SearchResults results={[]} onFileClick={mockOnFileClick} isLoading={true} />);
+
+    expect(screen.getByText('検索中...')).toBeInTheDocument();
+    const spinner = document.querySelector('.loading.loading-spinner');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('エラー状態を表示する', () => {
+    const errorMessage = '検索中にエラーが発生しました';
+    render(<SearchResults results={[]} onFileClick={mockOnFileClick} error={errorMessage} />);
+
+    expect(screen.getByText(`エラー: ${errorMessage}`)).toBeInTheDocument();
+    const alertDiv = document.querySelector('.alert.alert-error');
+    expect(alertDiv).toBeInTheDocument();
+  });
+
+  it('検索結果が空の場合メッセージを表示する', () => {
+    render(<SearchResults results={[]} onFileClick={mockOnFileClick} />);
+
+    expect(screen.getByText('検索結果がありません')).toBeInTheDocument();
+  });
+
+  it('ファイルクリック時にonFileClickが呼ばれる', () => {
+    render(<SearchResults results={mockResults} onFileClick={mockOnFileClick} />);
+
+    const firstResult = screen.getByText('file1.md').closest('div[class*="cursor-pointer"]');
+    fireEvent.click(firstResult!);
+
+    expect(mockOnFileClick).toHaveBeenCalledTimes(1);
+    expect(mockOnFileClick).toHaveBeenCalledWith('/path/to/file1.md');
+  });
+
+  it('複数の結果で各ファイルがクリック可能', () => {
+    render(<SearchResults results={mockResults} onFileClick={mockOnFileClick} />);
+
+    const firstResult = screen.getByText('file1.md').closest('div[class*="cursor-pointer"]');
+    const secondResult = screen.getByText('file2.md').closest('div[class*="cursor-pointer"]');
+
+    fireEvent.click(firstResult!);
+    fireEvent.click(secondResult!);
+
+    expect(mockOnFileClick).toHaveBeenCalledTimes(2);
+    expect(mockOnFileClick).toHaveBeenNthCalledWith(1, '/path/to/file1.md');
+    expect(mockOnFileClick).toHaveBeenNthCalledWith(2, '/path/to/folder/file2.md');
+  });
+
+  it('各結果にFileIconが表示される', () => {
+    render(<SearchResults results={mockResults} onFileClick={mockOnFileClick} />);
+
+    const fileIcons = document.querySelectorAll('.lucide-file');
+    expect(fileIcons).toHaveLength(2);
+  });
+
+  it('結果のホバー時にスタイルが変更される', () => {
+    render(<SearchResults results={mockResults} onFileClick={mockOnFileClick} />);
+
+    const firstResult = screen.getByText('file1.md').closest('div[class*="cursor-pointer"]');
+    expect(firstResult).toHaveClass('hover:bg-base-200');
+  });
+
+  it('長いファイル名とパスが適切にtruncateされる', () => {
+    const longResults: ISearchResult[] = [
+      {
+        path: '/very/long/path/that/should/be/truncated/when/displayed/in/the/ui/file.md',
+        name: 'very-long-filename-that-should-also-be-truncated-when-displayed.md',
+      },
+    ];
+
+    render(<SearchResults results={longResults} onFileClick={mockOnFileClick} />);
+
+    const fileName = screen.getByText(longResults[0].name);
+    const filePath = screen.getByText(longResults[0].path);
+
+    expect(fileName).toHaveClass('truncate');
+    expect(filePath).toHaveClass('truncate');
+  });
+
+  it('デフォルトpropsが正しく設定される', () => {
+    render(<SearchResults results={[]} onFileClick={mockOnFileClick} />);
+
+    expect(screen.queryByText('検索中...')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByText('検索結果がありません')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/Search/hooks/useSearch.test.ts
+++ b/src/renderer/components/Search/hooks/useSearch.test.ts
@@ -1,0 +1,244 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ISearchOptions, ISearchResult } from '../../../../types/search';
+import { useSearch } from './useSearch';
+
+// Mock useToast hook
+const mockShowToast = vi.fn();
+vi.mock('../../../hooks/useToast', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+  }),
+}));
+
+describe('useSearch', () => {
+  const mockSearchResults: ISearchResult[] = [
+    {
+      path: '/path/to/file1.md',
+      name: 'file1.md',
+      matches: [
+        {
+          line: 1,
+          content: 'This is a test file',
+          highlight: [10, 14],
+        },
+      ],
+    },
+    {
+      path: '/path/to/file2.md',
+      name: 'file2.md',
+    },
+  ];
+
+  const mockSearchOptions: ISearchOptions = {
+    searchIn: 'both',
+    caseSensitive: false,
+    useRegex: false,
+    maxResults: 100,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the mock for window.api.fs.searchFiles
+    window.api.fs.searchFiles = vi.fn();
+    mockShowToast.mockClear();
+  });
+
+  it('初期状態が正しく設定される', () => {
+    const { result } = renderHook(() => useSearch());
+
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.isSearching).toBe(false);
+    expect(result.current.searchError).toBe(null);
+  });
+
+  it('検索が成功した場合、結果が設定される', async () => {
+    (window.api.fs.searchFiles as any).mockResolvedValue(mockSearchResults);
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      await result.current.search('/root/path', 'test', mockSearchOptions);
+    });
+
+    expect(result.current.searchResults).toEqual(mockSearchResults);
+    expect(result.current.isSearching).toBe(false);
+    expect(result.current.searchError).toBe(null);
+  });
+
+  it('検索中はisSearchingがtrueになる', async () => {
+    let resolveSearch: (value: ISearchResult[]) => void;
+    const searchPromise = new Promise<ISearchResult[]>((resolve) => {
+      resolveSearch = resolve;
+    });
+    (window.api.fs.searchFiles as any).mockReturnValue(searchPromise);
+
+    const { result } = renderHook(() => useSearch());
+
+    // Start the search without awaiting
+    act(() => {
+      result.current.search('/root/path', 'test', mockSearchOptions);
+    });
+
+    // Check that isSearching is true while promise is pending
+    expect(result.current.isSearching).toBe(true);
+
+    // Resolve the promise and wait for the search to complete
+    await act(async () => {
+      resolveSearch!(mockSearchResults);
+    });
+
+    // Now isSearching should be false
+    expect(result.current.isSearching).toBe(false);
+  });
+
+  it('検索結果が0件の場合、トーストが表示される', async () => {
+    (window.api.fs.searchFiles as any).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      await result.current.search('/root/path', 'test', mockSearchOptions);
+    });
+
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.searchError).toBe(null);
+    expect(mockShowToast).toHaveBeenCalledWith('検索結果が見つかりませんでした', 'success');
+  });
+
+  it('検索エラーが発生した場合、エラーが設定される', async () => {
+    const errorMessage = 'ファイルの検索に失敗しました';
+    (window.api.fs.searchFiles as any).mockRejectedValue(new Error(errorMessage));
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      await result.current.search('/root/path', 'test', mockSearchOptions);
+    });
+
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.isSearching).toBe(false);
+    expect(result.current.searchError).toBe(errorMessage);
+    expect(mockShowToast).toHaveBeenCalledWith(errorMessage, 'error');
+  });
+
+  it('エラーがError以外の場合、デフォルトメッセージが設定される', async () => {
+    (window.api.fs.searchFiles as any).mockRejectedValue('String error');
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      await result.current.search('/root/path', 'test', mockSearchOptions);
+    });
+
+    expect(result.current.searchError).toBe('検索中にエラーが発生しました');
+    expect(mockShowToast).toHaveBeenCalledWith('検索中にエラーが発生しました', 'error');
+  });
+
+  it('clearSearchで状態がリセットされる', async () => {
+    (window.api.fs.searchFiles as any).mockResolvedValue(mockSearchResults);
+
+    const { result } = renderHook(() => useSearch());
+
+    // First, perform a search
+    await act(async () => {
+      await result.current.search('/root/path', 'test', mockSearchOptions);
+    });
+
+    expect(result.current.searchResults).toEqual(mockSearchResults);
+
+    // Then clear the search
+    act(() => {
+      result.current.clearSearch();
+    });
+
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.searchError).toBe(null);
+  });
+
+  it('連続した検索で前の結果がクリアされる', async () => {
+    const firstResults = [mockSearchResults[0]];
+    const secondResults = [mockSearchResults[1]];
+
+    (window.api.fs.searchFiles as any)
+      .mockResolvedValueOnce(firstResults)
+      .mockResolvedValueOnce(secondResults);
+
+    const { result } = renderHook(() => useSearch());
+
+    // First search
+    await act(async () => {
+      await result.current.search('/root/path', 'first', mockSearchOptions);
+    });
+
+    expect(result.current.searchResults).toEqual(firstResults);
+
+    // Second search
+    await act(async () => {
+      await result.current.search('/root/path', 'second', mockSearchOptions);
+    });
+
+    expect(result.current.searchResults).toEqual(secondResults);
+  });
+
+  it('検索前にエラーとresultsがクリアされる', async () => {
+    const errorMessage = 'Previous error';
+    (window.api.fs.searchFiles as any)
+      .mockRejectedValueOnce(new Error(errorMessage))
+      .mockResolvedValueOnce(mockSearchResults);
+
+    const { result } = renderHook(() => useSearch());
+
+    // First search with error
+    await act(async () => {
+      await result.current.search('/root/path', 'error', mockSearchOptions);
+    });
+
+    expect(result.current.searchError).toBe(errorMessage);
+
+    // Second search should clear the error
+    await act(async () => {
+      await result.current.search('/root/path', 'success', mockSearchOptions);
+    });
+
+    expect(result.current.searchError).toBe(null);
+    expect(result.current.searchResults).toEqual(mockSearchResults);
+  });
+
+  it('searchFiles APIが正しいパラメータで呼ばれる', async () => {
+    (window.api.fs.searchFiles as any).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSearch());
+
+    const rootPath = '/test/path';
+    const searchTerm = 'test query';
+    const options: ISearchOptions = {
+      searchIn: 'filename',
+      caseSensitive: true,
+      useRegex: true,
+      maxResults: 50,
+      excludeDirs: ['node_modules', '.git'],
+    };
+
+    await act(async () => {
+      await result.current.search(rootPath, searchTerm, options);
+    });
+
+    expect(window.api.fs.searchFiles).toHaveBeenCalledWith(rootPath, searchTerm, options);
+    expect(window.api.fs.searchFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('rootPathがnullでも検索が実行される', async () => {
+    (window.api.fs.searchFiles as any).mockResolvedValue(mockSearchResults);
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      await result.current.search(null, 'test', mockSearchOptions);
+    });
+
+    expect(window.api.fs.searchFiles).toHaveBeenCalledWith(null, 'test', mockSearchOptions);
+    expect(result.current.searchResults).toEqual(mockSearchResults);
+  });
+});


### PR DESCRIPTION
## Summary
- 空ファイル選択時にエディターが表示されない問題を修正
- `fileContent && ...` から `fileContent \!== null && fileContent \!== undefined && ...` に条件を変更
- 空文字列（''）がfalsyと評価されることによる問題を解決

## Test plan
- [x] 空ファイルを選択してエディターが表示されることを確認
- [x] 通常のファイルも正常に動作することを確認
- [x] 全テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)