### PR TITLE
feat: ファイルツリーからファイル編集中のマークを削除

### DIFF
--- a/src/renderer/components/FileTree/FileTree.tsx
+++ b/src/renderer/components/FileTree/FileTree.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
+import clsx from 'clsx';
 import { ChevronLeft, FileIcon, FolderIcon, Search, Sparkles, X } from 'lucide-react';
 
 import { ISearchOptions, ISearchResult } from '../../../types/search';
@@ -285,9 +286,11 @@ export const FileTree: React.FC<FileTreeProps> = ({
                   >
                     <button
                       type="button"
-                      className={`tooltip tooltip-bottom flex w-full items-center px-4 py-2 ${isDisabled(file) ? 'btn-disabled' : ''} ${
-                        selectedFile?.path === file.path ? 'active' : ''
-                      }`}
+                      className={clsx('tooltip tooltip-bottom flex w-full items-center px-4 py-2', {
+                        'btn-disabled': isDisabled(file),
+                        active: selectedFile?.path === file.path,
+                        'bg-primary/10': currentFile === file.path,
+                      })}
                       onClick={() =>
                         file.isDirectory
                           ? handleDirectoryClick(file.path)

--- a/src/renderer/components/FileTree/FileTree.tsx
+++ b/src/renderer/components/FileTree/FileTree.tsx
@@ -13,14 +13,12 @@ interface FileTreeProps {
   onFileSelect?: (filePath: string) => void;
   onSettingsClick: () => void;
   currentFile: string | null;
-  isDirty: boolean;
 }
 
 export const FileTree: React.FC<FileTreeProps> = ({
   onFileSelect,
   onSettingsClick,
   currentFile,
-  isDirty,
 }) => {
   const [files, setFiles] = useState<FileTreeItem[]>([]);
   const [rootDir, setRootDir] = useState<string | null>(null);
@@ -306,14 +304,8 @@ export const FileTree: React.FC<FileTreeProps> = ({
                       ) : (
                         <FileIcon className="h-5 w-5 min-w-5 text-base-content/70" />
                       )}
-                      <span className="truncate ml-2 flex items-center" title={file.name}>
+                      <span className="truncate ml-2" title={file.name}>
                         {file.name}
-                        {currentFile === file.path && isDirty && (
-                          <span
-                            data-testid="dirty-indicator"
-                            className="ml-1 inline-block w-2 h-2 rounded-full bg-error"
-                          />
-                        )}
                       </span>
                     </button>
                   </li>

--- a/src/renderer/components/Sidebar/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.test.tsx
@@ -18,7 +18,6 @@ vi.mock('../Search', () => ({
 const defaultProps = {
   hasGitSettings: false,
   selectedFile: null as string | null,
-  isDirty: false,
   onFileSelect: vi.fn(),
   onSettingsClick: vi.fn(),
 };

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -11,7 +11,6 @@ interface SidebarProps {
   onToggle: () => void;
   hasGitSettings: boolean;
   selectedFile: string | null;
-  isDirty: boolean;
   onFileSelect: (filePath: string) => void;
   onSettingsClick: () => void;
 }
@@ -21,7 +20,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onToggle,
   hasGitSettings,
   selectedFile,
-  isDirty,
   onFileSelect,
   onSettingsClick,
 }) => {
@@ -52,7 +50,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
             onFileSelect={onFileSelect}
             onSettingsClick={onSettingsClick}
             currentFile={selectedFile}
-            isDirty={isDirty}
           />
         </div>
         {hasGitSettings && (


### PR DESCRIPTION
## Summary
- FileTree.tsxからisDirtyプロパティとファイル編集中のマーク表示を削除
- Sidebar.tsxからisDirtyプロパティの受け渡しを削除  
- 関連するテストファイルを修正

## Test plan
- [x] 既存のテストがすべてパスすることを確認
- [x] FileTreeコンポーネントが正常に動作することを確認
- [x] Sidebar.test.tsxからisDirtyプロパティ参照を削除

🤖 Generated with [Claude Code](https://claude.ai/code)