### PR TITLE
refactor: 未使用のimportを削除し、型のみimportをimport typeに変更

### DIFF
--- a/src/main/ai/generativeAiHandler.ts
+++ b/src/main/ai/generativeAiHandler.ts
@@ -2,7 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import { ipcMain } from 'electron';
 
-import { AppSettings } from '../../types/appSettings';
+import type { AppSettings } from '../../types/appSettings';
 import { IPC_CHANNELS } from '../common/constants';
 import { validateSender } from '../common/security/ipcSecurity';
 

--- a/src/main/ai/streamHandler.ts
+++ b/src/main/ai/streamHandler.ts
@@ -2,7 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { streamText } from 'ai';
 import { ipcMain } from 'electron';
 
-import { AppSettings } from '../../types/appSettings';
+import type { AppSettings } from '../../types/appSettings';
 import { IPC_CHANNELS } from '../common/constants';
 import { validateSender } from '../common/security/ipcSecurity';
 

--- a/src/main/settings/settingsHandlers.ts
+++ b/src/main/settings/settingsHandlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 
-import { AppSettings } from '../../types/appSettings';
+import type { AppSettings } from '../../types/appSettings';
 import { IPC_CHANNELS } from '../common/constants';
 import { validateSender } from '../common/security/ipcSecurity';
 

--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -38,7 +38,7 @@ export interface EditorRefType {
 }
 
 export const Editor = ({ initialContent, className, ref, onDirtyChange }: EditorProps) => {
-  const [_, setFloatingAnchorElem] = useState<HTMLDivElement | null>(null);
+  const [, setFloatingAnchorElem] = useState<HTMLDivElement | null>(null);
   const savePluginRef = useRef<{ getMarkdown: () => string }>(null);
 
   // 外部のrefに内部のsavePluginRefの機能を公開

--- a/src/renderer/components/Editor/plugins/MarkdownTransformers.ts
+++ b/src/renderer/components/Editor/plugins/MarkdownTransformers.ts
@@ -88,7 +88,7 @@ export const TABLE: ElementTransformer = {
 
       output.push(`| ${rowOutput.join(' | ')} |`);
       if (isHeaderRow) {
-        output.push(`| ${rowOutput.map((_) => '---').join(' | ')} |`);
+        output.push(`| ${rowOutput.map(() => '---').join(' | ')} |`);
       }
     }
 

--- a/src/renderer/components/Editor/plugins/ToolbarPlugin.tsx
+++ b/src/renderer/components/Editor/plugins/ToolbarPlugin.tsx
@@ -161,7 +161,7 @@ export const ToolbarPlugin = () => {
       }),
       editor.registerCommand(
         SELECTION_CHANGE_COMMAND,
-        (_payload, _newEditor) => {
+        () => {
           $updateToolbar();
           return false;
         },

--- a/src/renderer/components/FileTree/FileTree.tsx
+++ b/src/renderer/components/FileTree/FileTree.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { ChevronLeft, FileIcon, FolderIcon, Search, Sparkles, X } from 'lucide-react';
 
-import { ISearchOptions, ISearchResult } from '../../../types/search';
+import type { ISearchOptions } from '../../../types/search';
 import { useToast } from '../../hooks/useToast';
 import { FileMenu, FileTreeItem } from '../FileMenu/FileMenu';
 import { SearchResults } from '../Search/SearchResults';

--- a/src/renderer/components/Search/SearchBar.test.tsx
+++ b/src/renderer/components/Search/SearchBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/src/renderer/components/Search/hooks/useSearch.ts
+++ b/src/renderer/components/Search/hooks/useSearch.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { ISearchOptions, ISearchResult } from '../../../../types/search';
+import type { ISearchOptions, ISearchResult } from '../../../../types/search';
 import { useToast } from '../../../hooks/useToast';
 
 export const useSearch = () => {

--- a/src/renderer/hooks/useAIStream.ts
+++ b/src/renderer/hooks/useAIStream.ts
@@ -54,7 +54,7 @@ export function useAIStream({ onChunk, onComplete, onError }: UseAIStreamOptions
       onChunkRef.current?.(chunk);
     };
 
-    const handleEnd = (_event: any) => {
+    const handleEnd = () => {
       console.log('ストリーム終了');
       setIsStreaming(false);
       onCompleteRef.current?.(fullTextRef.current);


### PR DESCRIPTION
## Summary
- 未使用のnamed importを削除（ISearchResult、fireEvent、waitFor等）
- 未使用のパラメータ変数を削除（_変数）
- 型のみで使用されているimportをimport typeに変更してバンドルサイズを最適化

## Test plan
- [x] npm run testでテストが通ることを確認
- [x] npm run startでアプリが起動することを確認
- [x] npm run packageでビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)