### PR TITLE
refactor: interfaceをtypeに変更

### DIFF
--- a/src/main/fileSystem/fileSearchHandler.ts
+++ b/src/main/fileSystem/fileSearchHandler.ts
@@ -4,15 +4,15 @@ import path from 'node:path';
 
 import { validateFilePath } from '../common/security/ipcSecurity';
 
-export interface ISearchOptions {
+export type ISearchOptions = {
   searchIn: 'filename' | 'content' | 'both';
   caseSensitive?: boolean;
   useRegex?: boolean;
   maxResults?: number;
   excludeDirs?: string[];
-}
+};
 
-export interface ISearchResult {
+export type ISearchResult = {
   path: string;
   name: string;
   matches?: {
@@ -20,7 +20,7 @@ export interface ISearchResult {
     content: string;
     highlight: [number, number];
   }[];
-}
+};
 
 type ISearchContext = {
   searchPattern: RegExp | string;

--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -33,9 +33,9 @@ type EditorProps = {
   onDirtyChange: (dirty: boolean) => void;
 };
 
-export interface EditorRefType {
+export type EditorRefType = {
   getMarkdown: () => string;
-}
+};
 
 export const Editor = ({ initialContent, className, ref, onDirtyChange }: EditorProps) => {
   const [, setFloatingAnchorElem] = useState<HTMLDivElement | null>(null);

--- a/src/renderer/hooks/useAIStream.ts
+++ b/src/renderer/hooks/useAIStream.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-export interface UseAIStreamOptions {
+export type UseAIStreamOptions = {
   onChunk?: (chunk: string) => void;
   onComplete?: (fullText: string) => void;
   onError?: (error: string) => void;
-}
+};
 
 export function useAIStream({ onChunk, onComplete, onError }: UseAIStreamOptions = {}) {
   const [isStreaming, setIsStreaming] = useState(false);

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,12 +1,12 @@
-export interface ISearchOptions {
+export type ISearchOptions = {
   searchIn: 'filename' | 'content' | 'both';
   caseSensitive?: boolean;
   useRegex?: boolean;
   maxResults?: number;
   excludeDirs?: string[];
-}
+};
 
-export interface ISearchResult {
+export type ISearchResult = {
   path: string;
   name: string;
   matches?: {
@@ -14,4 +14,4 @@ export interface ISearchResult {
     content: string;
     highlight: [number, number];
   }[];
-}
+};


### PR DESCRIPTION
## Summary
- プロジェクト全体でinterfaceをtypeに統一
- Window interfaceは型拡張のため変更せず
- 重複している型定義も同時に修正

## 変更内容
- `ISearchOptions`、`ISearchResult`をtypeに変更
- `EditorRefType`をtypeに変更  
- `UseAIStreamOptions`をtypeに変更
- `;`の追加によるフォーマット統一

## Test plan
- [x] `npm run test`でテストが全て通ることを確認済み
- [x] `npm run start`でアプリが正常に起動することを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)