### PR TITLE
Fix eslint errors and loop logic

### DIFF
--- a/src/renderer/components/AppSettings/AppSettings.test.tsx
+++ b/src/renderer/components/AppSettings/AppSettings.test.tsx
@@ -317,6 +317,7 @@ describe('AppSettings', () => {
   describe('エラーハンドリング', () => {
     test('設定読み込みエラー時にコンソールエラーが出力される', async () => {
       // Given: 設定読み込みが失敗する設定
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       mockApi.app.getSettings.mockRejectedValue(new Error('読み込みエラー'));
 
@@ -333,6 +334,7 @@ describe('AppSettings', () => {
 
     test('設定保存エラー時にコンソールエラーが出力される', async () => {
       // Given: 設定保存が失敗する設定
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       mockApi.app.setSettings.mockRejectedValue(new Error('保存エラー'));
       const user = userEvent.setup();

--- a/src/renderer/components/GitOps/GitControls.tsx
+++ b/src/renderer/components/GitOps/GitControls.tsx
@@ -32,6 +32,7 @@ export const GitControls: React.FC<GitControlsProps> = ({ selectedFile }) => {
   return (
     <div className="card">
       <div className="card-body">
+        {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
         <div className="flex cursor-pointer items-center justify-between" onClick={() => {}}>
           <h3 className="card-title text-lg">Git操作</h3>
           <span className="text-base-content/70"></span>

--- a/src/renderer/components/GitOps/hooks/useGitControl.ts
+++ b/src/renderer/components/GitOps/hooks/useGitControl.ts
@@ -1,7 +1,12 @@
-import { GitStatus, HeadStatus, StageStatus, StatusMatrix, WorkdirStatus } from '@/types/gitStatus';
-
 import { useEffect, useMemo, useState } from 'react';
 
+import {
+  GitStatus,
+  HeadStatus,
+  StageStatus,
+  StatusMatrix,
+  WorkdirStatus,
+} from '../../../../types/gitStatus';
 import { getFileNameFromPath } from '../functions/getFileName';
 
 type UseGitControlProps = {

--- a/src/renderer/components/Toast/Toast.tsx
+++ b/src/renderer/components/Toast/Toast.tsx
@@ -1,8 +1,7 @@
-import { toastAtom } from '@/renderer/stores/toastAtom';
-
 import { useAtomValue } from 'jotai';
 import { X } from 'lucide-react';
 
+import { toastAtom } from '../../stores/toastAtom';
 import { useToast } from './hooks/useToast';
 
 export const Toast = () => {

--- a/src/renderer/hooks/useFileLoader.ts
+++ b/src/renderer/hooks/useFileLoader.ts
@@ -58,7 +58,8 @@ export function useFileLoader(filePath: string | null, onLoadComplete?: (content
     let loadedContent = '';
 
     try {
-      while (true) {
+      let hasMore = true;
+      while (hasMore) {
         // 行単位で読み込む
         const chunk = await window.api.fs.readFileLines(path, startLine, LINES_PER_CHUNK);
 
@@ -83,7 +84,7 @@ export function useFileLoader(filePath: string | null, onLoadComplete?: (content
         await new Promise((resolve) => setTimeout(resolve, 10));
 
         if (chunk.length < LINES_PER_CHUNK) {
-          break; // 最後のチャンクなら終了
+          hasMore = false; // 最後のチャンクなら終了
         }
       }
 


### PR DESCRIPTION
## Summary
- fix large file loader loop to avoid constant condition
- silence expected empty functions for tests and onClick handler
- fix import paths for git status and toast store

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68647e014f008329b48e287bdc5f59ad